### PR TITLE
Remove ss, ssd, and half checkboxes

### DIFF
--- a/client/src/components/JayRadar.tsx
+++ b/client/src/components/JayRadar.tsx
@@ -41,9 +41,6 @@ function JayRadar() {
     },
     dl: {
       active: false,
-      ss: false,
-      ssd: false,
-      half: false,
       conf: 0,
       iou: 0,
       max: 0,

--- a/client/src/components/Tabs/Yolov8Tab.tsx
+++ b/client/src/components/Tabs/Yolov8Tab.tsx
@@ -22,36 +22,6 @@ function Yolov8Tab({ options, handleChange }: Props) {
           />
           <label htmlFor="dl/active">Active</label>
         </div>
-        <div>
-          <input
-            type="checkbox"
-            id="dl/ss"
-            name="dl/ss"
-            checked={options.ss}
-            onChange={handleChange}
-          />
-          <label htmlFor="dl/ss">SS</label>
-        </div>
-        <div>
-          <input
-            type="checkbox"
-            id="dl/ssd"
-            name="dl/ssd"
-            checked={options.ssd}
-            onChange={handleChange}
-          />
-          <label htmlFor="dl/ssd">SSD</label>
-        </div>
-        <div>
-          <input
-            type="checkbox"
-            id="dl/half"
-            name="dl/half"
-            checked={options.half}
-            onChange={handleChange}
-          />
-          <label htmlFor="dl/half">Half Precision</label>
-        </div>
       </div>
       <div className="sliders">
         <div>

--- a/client/src/types/Yolov8ConfigOptions.ts
+++ b/client/src/types/Yolov8ConfigOptions.ts
@@ -2,9 +2,6 @@ import { BaseConfigOptions } from './BaseConfigOptions';
 
 export interface Yolov8ConfigOptions extends BaseConfigOptions {
   active: boolean;
-  ss: boolean;
-  ssd: boolean;
-  half: boolean;
   conf: number;
   iou: number;
   max: number;


### PR DESCRIPTION
Removed the following checkboxes/options from the yolov8 config + tab
- ss
- ssd
- half